### PR TITLE
💄 style: header높이 변경에 따른 body최소 높이 수치 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,13 +40,12 @@
 }
 
 main {
-  margin-top: 50px;
-  min-height: calc(100vh - 160px);
+  padding-top: 50px;
+  min-height: calc(100vh - 122px);
 }
 
 @media (min-width: 1280px) {
   main {
-    margin-top: 80px;
-    min-height: calc(100vh - 210px);
+    padding-top: 80px;
   }
 }


### PR DESCRIPTION
최근 header높이가 변경되어 body에 불필요한 스크롤이 생기고 있었음.
body최소 높이 수치를 조정함으로서 body에 스크롤 안생기게 처리함

- margin-top -> padding-top 으로 변경
- min-height: calc(100vh - 160px); -> min-height: calc(100vh - 122px); 로 변경